### PR TITLE
[ENG-4669] Ensure html_escape marks result as html_safe

### DIFF
--- a/lib/angular_xss/erb.rb
+++ b/lib/angular_xss/erb.rb
@@ -3,33 +3,33 @@ ERB::Util.module_eval do
 
   if private_method_defined? :unwrapped_html_escape # Rails 4.2+
 
-    def unwrapped_html_escape_with_escaping_angular_expressions(s)
+    def unwrapped_html_escape_with_escaping_angular_expressions_erb(s)
       s = s.to_s
       if s.html_safe?
         s
       else
-        unwrapped_html_escape_without_escaping_angular_expressions(AngularXss::Escaper.escape(s))
+        unwrapped_html_escape_without_escaping_angular_expressions_erb(AngularXss::Escaper.escape(s)).html_safe
       end
     end
 
-    alias_method_chain :unwrapped_html_escape, :escaping_angular_expressions
+    alias_method_chain :unwrapped_html_escape, :escaping_angular_expressions_erb
 
     singleton_class.send(:remove_method, :unwrapped_html_escape)
     module_function :unwrapped_html_escape
-    module_function :unwrapped_html_escape_without_escaping_angular_expressions
+    module_function :unwrapped_html_escape_without_escaping_angular_expressions_erb
 
   else # Rails < 4.2
 
-    def html_escape_with_escaping_angular_expressions(s)
+    def html_escape_with_escaping_angular_expressions_erb(s)
       s = s.to_s
       if s.html_safe?
         s
       else
-        html_escape_without_escaping_angular_expressions(AngularXss::Escaper.escape(s))
+        html_escape_without_escaping_angular_expressions_erb(AngularXss::Escaper.escape(s)).html_safe
       end
     end
 
-    alias_method_chain :html_escape, :escaping_angular_expressions
+    alias_method_chain :html_escape, :escaping_angular_expressions_erb
 
     # Aliasing twice issues a warning "discarding old...". Remove first to avoid it.
     remove_method(:h)
@@ -39,7 +39,7 @@ ERB::Util.module_eval do
 
     singleton_class.send(:remove_method, :html_escape)
     module_function :html_escape
-    module_function :html_escape_without_escaping_angular_expressions
+    module_function :html_escape_without_escaping_angular_expressions_erb
 
   end
 

--- a/lib/angular_xss/haml.rb
+++ b/lib/angular_xss/haml.rb
@@ -1,15 +1,15 @@
 # Use module_eval so we crash when Haml::Helpers has not yet been loaded.
 Haml::Helpers.module_eval do
 
-  def html_escape_with_escaping_angular_expressions(s)
+  def html_escape_with_escaping_angular_expressions_haml(s)
     s = s.to_s
     if s.html_safe?
       s
     else
-      html_escape_without_escaping_angular_expressions(AngularXss::Escaper.escape(s))
+      html_escape_without_escaping_angular_expressions_haml(AngularXss::Escaper.escape(s)).html_safe
     end
   end
 
-  alias_method_chain :html_escape, :escaping_angular_expressions
+  alias_method_chain :html_escape, :escaping_angular_expressions_haml
 
 end


### PR DESCRIPTION
### Jira Issue: https://cloudhealthtech.atlassian.net/browse/ENG-4669
### Associated PR: https://github.com/CloudHealth/cloudpercept/pull/11661

*Note:* We are choosing to diverge from the [source project](https://github.com/makandra/angular_xss) without opening a PR with them due to the nature of these changes being specific to our configuration. I don't expect much activity on that project, due to a more [popular alternative](https://github.com/opf/rails-angular-xss) which requires Rails 5+, so I don't think we're at risk of missing out on any updates.

## Overview
Prevent double-escaping within HTML attributes that have already been escaped.

When `<%= h("{"id":"example"}") %>`is evaluated, `h` references
`ERB::Util#html_escape_with_escaping_angular_expressions_erb` which
calls out first to our custom `Escaper`, and the result is then passed
to the original `#html_escape` method that was saved off as
`#html_escape_without_escaping_angular_expressions_erb` when creating a
decorated alias.

In this case, we expect
`#html_escape_without_escaping_angular_expressions_erb` points to
`ERB::Util#html_escape` which performs the escaping and marks the result
as `html_safe`. However, the alias points to `Haml::Helpers#html_escape`
which does NOT mark the result as `html_safe`. As such, we encounter the
following problem:

`<div attribute="<%= h('{"key":"value"}') %>"></div>`

1. Any Ruby snippets in the template are executed:
`h('{"key":"value"}')` => `'{&quot;key&quot;:&quot;value&quot;}'`

2. Rails auto-escapes all attributes by default
`'{&quot;key&quot;:&quot;value&quot;}'` =>
`'{&amp;quot;key&amp;quot;:&amp;quot;value&amp;quot;}'`

Because the result of (1) is not marked as `html_safe`, instances of
`"&"` are re-escaped during the auto-escaping step, resulting in an
invalid attribute value when rendered by the client.

Our change ensures that whatever we return from
`ERB::Util#html_escape_with_escaping_angular_expressions_erb` and
`Haml::Helpers#html_escape_with_escaping_angular_expressions_haml` is
marked as `html_safe` to prevent double-escaping.

Follow-Up:
We've tested the 4 combinations of using `h` and `html_escape` in both
`.html.haml` and `.html.erb` files to better understand the code paths
that are executed in this monkey-patched world we live in.

The results are interesting:

* From within an ERB file:
  * `html_escape`
    * Points to `Haml::Helpers::XssMods#html_escape_with_haml_xss`
    (NOTE: This method returns an `html_safe` string once escaped—see)
      * Which then calls to
      `Haml::Helpers#html_escape_with_escaping_angular_expressions_haml`
        * Which then calls to the original `Haml::Helpers#html_escape`
  * `h`
    * Points to
    `ERB::Util#html_escape_with_escaping_angular_expression_erb`
      * Which then calls to the original `ERB::Util#html_escape`
      (NOTE: This method returns an `html_safe` string once escaped)
* From within a HAML file:
  * `html_escape`
    * Points to `Haml::Helpers::XssMods#html_escape_with_haml_xss`
    (NOTE: This method returns an `html_safe` string once escaped—see)
      * Which then calls to
      `Haml::Helpers#html_escape_with_escaping_angular_expressions_haml`
        * Which then calls to the original `Haml::Helpers#html_escape`
    * `h`
      * Points to
      `ERB::Util#html_escape_with_escaping_angular_expression_erb`
        * Which then calls to the original `ERB::Util#html_escape`
        (NOTE: This method returns an `html_safe` string once escaped)

Note that in all cases, the string ends up `html_escaped` by an existing
function, but also note that we get some unexpected behavior--Haml
calls are made from within `.html.erb` files, and ERB calls are made
within `.html.haml` files. The results are difficult to predict, and
likely depend on load-order and monkey-patching order, something that
is difficult to control.

As such, we choose to mark the results of our aliased methods as
`html_safe` as an added layer of protection in case one of the calls
in the chain ever unknowingly points to a call to `html_escape` which
does NOT mark the result as `html_safe`. But have no fear, `html_safe`
is an idempotent operation, so we won't harm anything that's already
been marked as such.

## Testing / Verification

### Steps to Reproduce

Checkout the following:
`cloudhealth`: `e534695d3381a8b1763a799ae3d9c7ad09c2bcdf` (initial commit which surfaced the error)
`angular_xss`: `master`

0. `bundle install`, restart `zeus`, then run `grunt`
1. Visit http://127.0.0.1:3000/organizations/206158430216/users
2. Open the Console and inspect an error (`Unexpected token & in JSON at position 1`)
3. Search the DOM for `organization-user-config` and verify the `data-organization-json` attribute contains escaped quotes (the result of double-escaping in Rails). It should look something like `{&quot;id&quot;:206158430216...`. This is the error we're solving for.

### Solution Verification

Checkout the following:
`cloudhealth`: `revert-11609-brandonread/disable-angular-xss`
`angular_xss`: `brandonread/mark-haml-html-escaped-result-as-html-safe`

0. `bundle install`, restart `zeus`, then run `grunt`
1. Visit http://127.0.0.1:3000/organizations/206158430216/users
2. Open the Console and verify no errors appear
3. Search the DOM for `organization-user-config` and verify the `data-organization-json` attribute does not show any escaped quotes. It should look something like `{"id":206158430216...`. This is the correct output, escaped once in Rails, and unescaped properly by the client.

### Verifying the Original Fix still Works
Follow the instructions in the Testing / Verification section of the [PR for the initial fix](https://github.com/CloudHealth/cloudpercept/pull/11576). You can verify the bug from `cloudpercept`: `master` branch, and the fix using the branches mentioned in the **Solution Verification** section above.